### PR TITLE
Fix security definer view

### DIFF
--- a/project/16_fix_order_items_with_pricing_security.sql
+++ b/project/16_fix_order_items_with_pricing_security.sql
@@ -1,0 +1,36 @@
+-- Migration 16: Fix security issue with order_items_with_pricing view
+-- Remove SECURITY DEFINER property to use SECURITY INVOKER (default)
+-- This ensures the view respects the querying user's permissions and RLS policies
+
+-- Extract the view definition and recreate it without SECURITY DEFINER
+DO $$
+DECLARE
+  view_def text;
+BEGIN
+  -- Check if view exists
+  IF EXISTS (
+    SELECT 1 FROM pg_views 
+    WHERE schemaname = 'public' AND viewname = 'order_items_with_pricing'
+  ) THEN
+    -- Get the view definition using pg_get_viewdef
+    SELECT pg_get_viewdef('public.order_items_with_pricing', true) INTO view_def;
+    
+    -- Drop the existing view
+    DROP VIEW IF EXISTS public.order_items_with_pricing CASCADE;
+    
+    -- Recreate the view without SECURITY DEFINER (defaults to SECURITY INVOKER)
+    -- pg_get_viewdef returns the SELECT statement, so we wrap it in CREATE VIEW
+    EXECUTE format('CREATE VIEW public.order_items_with_pricing AS %s', view_def);
+    
+    -- Add comment for documentation
+    EXECUTE 'COMMENT ON VIEW public.order_items_with_pricing IS ''View joining order_items with products and orders to include pricing and product details. Uses SECURITY INVOKER (default) to respect querying user permissions and RLS policies.''';
+    
+    RAISE NOTICE 'View order_items_with_pricing recreated without SECURITY DEFINER';
+  ELSE
+    RAISE NOTICE 'View order_items_with_pricing not found, skipping migration';
+  END IF;
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE WARNING 'Error recreating view: %', SQLERRM;
+    RAISE;
+END $$;


### PR DESCRIPTION
Remove `SECURITY DEFINER` from `public.order_items_with_pricing` view to fix a security vulnerability and enforce querying user's permissions.

The `SECURITY DEFINER` property caused the view to run with the privileges of the view creator, potentially bypassing the querying user's Row Level Security (RLS) policies. By removing it, the view defaults to `SECURITY INVOKER`, ensuring that the view respects the permissions and RLS policies of the user executing the query.

---
<a href="https://cursor.com/background-agent?bcId=bc-f27b8e11-860a-4dd3-828a-bc0da23631d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f27b8e11-860a-4dd3-828a-bc0da23631d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

