### PR TITLE
Product page scroll persistence

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -54,6 +54,8 @@ function AppContent() {
   const [isProductDetailOpen, setIsProductDetailOpen] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [viewingProduct, setViewingProduct] = useState<Product | null>(null);
+  const [productListScrollY, setProductListScrollY] = useState(0);
+  const [shouldRestoreProductListScroll, setShouldRestoreProductListScroll] = useState(false);
 
   // Fetch data from Supabase
   useEffect(() => {
@@ -98,6 +100,23 @@ function AppContent() {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    if (activeTab !== 'products' || !shouldRestoreProductListScroll) {
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const restoreScroll = () => {
+      window.scrollTo(0, productListScrollY);
+      setShouldRestoreProductListScroll(false);
+    };
+
+    requestAnimationFrame(restoreScroll);
+  }, [activeTab, productListScrollY, shouldRestoreProductListScroll]);
+
   const handleSaveProduct = async (product: Omit<Product, 'id' | 'created_at' | 'updated_at'>) => {
     console.log('handleSaveProduct called with:', product);
     console.log('Current stock in product data:', product.current_stock);
@@ -137,6 +156,11 @@ function AppContent() {
   };
 
   const handleEditProduct = (product: Product) => {
+    if (activeTab === 'products' && typeof window !== 'undefined') {
+      setProductListScrollY(window.scrollY);
+      setShouldRestoreProductListScroll(true);
+    }
+
     setEditingProduct(product);
     setActiveTab('edit-product');
   };

--- a/project/src/components/ProductList.tsx
+++ b/project/src/components/ProductList.tsx
@@ -695,7 +695,7 @@ export const ProductList: React.FC<ProductListProps> = ({
     filters.isTester !== null;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" data-product-list="container">
       <PageHeader
         title="Products"
         subtitle={`${sortedProducts.length} of ${products.length} products`}

--- a/project/src/components/shared/Table.tsx
+++ b/project/src/components/shared/Table.tsx
@@ -115,6 +115,7 @@ export function Table<T extends { id: string }>({
           {data.map((item) => (
             <tr
               key={item[keyField as keyof T] as string}
+              data-row-id={String(item[keyField as keyof T])}
               className={`${
                 onRowClick ? 'cursor-pointer hover:bg-gray-50' : ''
               }`}


### PR DESCRIPTION
Capture and restore product list scroll position to maintain user context after editing a product.

This prevents the user from losing their place in the product list when returning from the product edit page, enhancing usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-b67d57ec-eb0e-410b-a76b-be41346ac380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b67d57ec-eb0e-410b-a76b-be41346ac380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

